### PR TITLE
Feat: 상세페이지에서 unft 상세조회API에 쿠키로 조회수 구현

### DIFF
--- a/static/js/detailAPI.js
+++ b/static/js/detailAPI.js
@@ -8,7 +8,6 @@ function getParams(params){
     const get_urlParams = urlParams.get(params);
     return get_urlParams;
 }
-
 async function handleUnftDetail(){
      // url이 ?q="unft=1" 형태로 입력되지 않았을 때 에러메세지 출력
     url_param = getParams("unft");
@@ -20,6 +19,7 @@ async function handleUnftDetail(){
             "content-type": "application/json",
             // "Authorization":"Bearer " + localStorage.getItem("access")
         },
+        credentials: "include",
         method:'GET',
     }).then(response => {
         if(!response.ok){
@@ -28,7 +28,6 @@ async function handleUnftDetail(){
         return response.json()
     }).then(result => {
         const response_json = result;
-        console.log(response_json)
         append_unft_card_detail(response_json)
         // let unft_card_list = document.getElementById("unft_card_list").querySelector(".row")
         // append_unft_card_list(response_json,unft_card_list)

--- a/static/js/detailAPI.js
+++ b/static/js/detailAPI.js
@@ -17,7 +17,6 @@ async function handleUnftDetail(){
     const response = await fetch('http://127.0.0.1:8000/unft/'+url_param+'/',{
         headers: {
             "content-type": "application/json",
-            // "Authorization":"Bearer " + localStorage.getItem("access")
         },
         credentials: "include",
         method:'GET',
@@ -29,15 +28,12 @@ async function handleUnftDetail(){
     }).then(result => {
         const response_json = result;
         append_unft_card_detail(response_json)
-        // let unft_card_list = document.getElementById("unft_card_list").querySelector(".row")
-        // append_unft_card_list(response_json,unft_card_list)
         
     }).catch(error => {
         console.warn(error.message)
     });
 }
 function append_unft_card_detail(data){
-    console.log(data)
     const element = document.querySelector(".item_detail_card");
     element.querySelector(".title").innerText = data['title']
     element.querySelector(".id").innerText = "#"+data['id']


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 디자인 변경
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/13-unftViewCnt -> main

## 변경 사항
1. 상세페이지에서 unft 상세조회API 호출시 쿠키도 같이 전달
            - fetch에서는 자동으로 쿠키를 전달/저장하지 않음
            - fetch에서 credentials를 설정해줘야함.
2. 불필요한 console.log 삭제


## 테스트 결과
변경 사항을 설명하는데 도움이 되는 스크린샷이나 참고 자료를 추가해주세요.

![Screenshot 2022-11-25 at 12 35 06 PM](https://user-images.githubusercontent.com/12287842/203896321-3f8d2c22-dcf4-479f-8117-25ccd742c6dc.png)