### PR TITLE
Feat: U-NFT 수정 페이지 UI 및 unft 수정 API 연결

### DIFF
--- a/edit_unft.html
+++ b/edit_unft.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>U-NFT</title>
+    <!-- 페이지 meta태그 -->
+    <meta name=”description” content=”페이지 설명”>
+    <meta name=”keywords” content=”페이지에,들어간,키워드,단어로,입력,구분은,쉼표로”>
+    <meta property="og:site_name" content="The Rock" />
+    <meta property="og:title" content="The Rock Content" />
+    <meta property="og:description" content="Sean Connery found fame and fortune as the suave, sophisticated British agent, James Bond." />	
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://www.imdb.com/title/tt0117500/" />
+    <meta property="og:image" content="https://ia.media-imdb.com/images/rock.jpg" />
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+
+    <!-- JS -->
+    <script src="https://code.jquery.com/jquery-3.6.1.min.js" integrity="sha256-o88AwQnZB+VDvE9tvIXrMQaPlFFSUTR+nldQm1LuPXQ=" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-u1OknCvxWvY5kfmNBILK2hRnQC3Pr17a+RTT6rIHI7NnikvbZlHgTPOOmMi466C8" crossorigin="anonymous"></script>
+
+    <!-- CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-iYQeCzEYFbKjA/T2uDLTpkwGzCiq6soy8tYaI1GyVh/UjpbCx/TYkiZhlZB6+fzT" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.2/font/bootstrap-icons.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reset-css@5.0.1/reset.min.css">
+    <link rel="stylesheet" href="/static/css/style.css">
+    <!-- 페이지별 css 추가 -->
+    <link rel="stylesheet" href="/static/css/create_unft.css">
+</head>
+<body>
+    <header class="header_sticky">
+        <div class="container">
+            <nav>
+                <div class="flex">
+                    <div class="navbar_logo">
+                        <a href="/">
+                            <img src="/static/images/logo.png" alt="unftlogo" />
+                        </a>
+                    </div>
+                    <div class="navbar_nav flex w-100">
+                        <ul class="navbar_menu nav-left">
+                            <li class="navbar_item">
+                                <a href="#">
+                                    U-NFT 생성
+                                </a>
+                            </li>
+                        </ul>
+                        <ul class="navbar_menu nav-right">
+                            <li class="navbar_item">
+                                <a href="/profile.html">
+                                    <div class="my_money">
+                                        <i class="bi bi-wallet2"></i>
+                                        <p>
+                                            <span class="money"> 1,000,000 </span> USD
+                                        </p>
+                                    </div>
+                                </a>
+                            </li>
+                            <li class="navbar_item">
+                                <a href="/profile.html">
+                                    USERNAME
+                                </a>
+                            </li>
+                            <li class="navbar_item">
+                                <a href="#" onclick="handleLogout()">
+                                    SIGNOUT
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </nav>
+        </div>
+    </header>
+    <div class="wrap">
+        <div class="container">
+            <section class="sec sec_unft_form create_unft">
+                <div class= "container_create_main">
+                    <div class="create_content">
+                        <h1 class="create_title">U-NFT 수정하기</h1>
+                    </div>
+
+                    <div class="upload_text">
+                        <p class="result_text">결과 이미지</p>
+                    </div>
+                    <div class="upload_image">
+                        <div>
+                            <div class="unft_images item_image">
+                                <img aria-hidden="false" draggable="false" loading="lazy" src="https://files.metapie.io/images/banners/pc/2022-11-11 10:17:10.583519/11-2-02_pc_v2.png">
+                            </div>
+                        </div>
+                    </div>
+                    <div class="image_content">
+                        <div class="mb-3">
+                            <label for="exampleFormControlInput1" class="form-label">제목(최소 4자/최대 50자)</label>
+                            <input id="title" type="text" class="form-control" placeholder="U-NFT의 제목을 입력해주세요!">
+                        </div>
+                        <div class="mb-3">
+                            <label for="exampleFormControlTextarea1" class="form-label">U-NFT  소개</label>
+                            <textarea id="desc" class="form-control" placeholder="U-NFT를 소개해주세요." rows="15"></textarea>
+                        </div>
+                        <div class="mb-3">
+                            <label for="exampleFormControlInput1" class="form-label">크리에이터</label>
+                            <input id="creator" class="form-control" type="text" placeholder="username" aria-label="Disabled input example" disabled>
+                        </div>
+                        <div class="mb-3">
+                            <label for="exampleFormControlInput1" class="form-label">판매여부</label>
+                            <select id="status" class="form-select" aria-label="Default select example">
+                                <option selected>판매여부를 선택해주세요.</option>
+                                <option value="False">미판매</option>
+                                <option value="True">판매중</option>
+                            </select>
+                        </div>
+                        <div class="mb-3">
+                            <label for="exampleFormControlInput1" class="form-label">판매가격(USD)</label>
+                            <input id="price" type="text" class="form-control" placeholder="가격을 입력해주세요!">
+                        </div>
+                        <div class="floating_form mb-3">
+                            <button type="button" class="btn btn-primary"  id="create_button" onclick="handleCreateUnft()"> 생성하기</button>
+                            <button type="button" class="btn btn-primary"  id="cancel_button" onclick="location.href='index.html';"> 취소하기</button>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        </div>
+    </div>
+    <footer>
+
+    </footer>
+    <!-- JS 파일 -->
+    <script src="static/js/create_unft.js"></script>
+    <script src="static/js/logout.js"></script>
+</body>

--- a/edit_unft.html
+++ b/edit_unft.html
@@ -95,11 +95,11 @@
                     <div class="image_content">
                         <div class="mb-3">
                             <label for="exampleFormControlInput1" class="form-label">제목(최소 4자/최대 50자)</label>
-                            <input id="title" type="text" class="form-control" placeholder="U-NFT의 제목을 입력해주세요!">
+                            <input id="title" type="text" class="form-control" Disabled placeholder="U-NFT의 제목을 입력해주세요!">
                         </div>
                         <div class="mb-3">
                             <label for="exampleFormControlTextarea1" class="form-label">U-NFT  소개</label>
-                            <textarea id="desc" class="form-control" placeholder="U-NFT를 소개해주세요." rows="15"></textarea>
+                            <textarea id="desc" class="form-control" Disabled placeholder="U-NFT를 소개해주세요." rows="15"></textarea>
                         </div>
                         <div class="mb-3">
                             <label for="exampleFormControlInput1" class="form-label">크리에이터</label>
@@ -108,9 +108,9 @@
                         <div class="mb-3">
                             <label for="exampleFormControlInput1" class="form-label">판매여부</label>
                             <select id="status" class="form-select" aria-label="Default select example">
-                                <option selected>판매여부를 선택해주세요.</option>
-                                <option value="False">미판매</option>
-                                <option value="True">판매중</option>
+                                <option value="" disabled selected>판매여부를 선택해주세요.</option>
+                                <option value="false">미판매</option>
+                                <option value="true">판매중</option>
                             </select>
                         </div>
                         <div class="mb-3">
@@ -118,7 +118,7 @@
                             <input id="price" type="text" class="form-control" placeholder="가격을 입력해주세요!">
                         </div>
                         <div class="floating_form mb-3">
-                            <button type="button" class="btn btn-primary"  id="create_button" onclick="handleCreateUnft()"> 생성하기</button>
+                            <button type="button" class="btn btn-primary"  id="btn_update_unft">수정하기</button>
                             <button type="button" class="btn btn-primary"  id="cancel_button" onclick="location.href='index.html';"> 취소하기</button>
                         </div>
                     </div>
@@ -130,6 +130,6 @@
 
     </footer>
     <!-- JS 파일 -->
-    <script src="static/js/create_unft.js"></script>
+    <script src="static/js/edit_unft_api.js"></script>
     <script src="static/js/logout.js"></script>
 </body>

--- a/static/css/create_unft.css
+++ b/static/css/create_unft.css
@@ -105,3 +105,91 @@
     margin-left: 70px;
     margin-right: 70px;
 }
+
+
+/* sec_unft_form : from(생성,수정) 스타일 좀더 다듬기 */
+.sec_unft_form{
+    max-width: 900px;
+    margin: auto;
+}
+.sec_unft_form .upload_text{
+    width: 100%;
+    display: flex;
+    margin: 0;
+    margin-bottom: 16px;
+}
+.sec_unft_form .upload_text > p{
+    font-weight: 600;
+    text-align: center;
+    width: calc(50% - 16px);
+    padding: 16px 16px;
+    border-radius: 50px;
+    background-color: #fff;
+    box-shadow: 0 4px 10px rgb(0 0 0 / 10%);
+}
+.sec_unft_form .upload_image{
+    display: flex;
+    width: 100%;
+    height: auto;
+}
+.sec_unft_form .upload_image > div{
+    width: calc(50% - 16px);
+}
+.sec_unft_form .upload_image .item_image{
+    vertical-align: unset;
+    width: 100%;
+    padding-top: 100%;
+    position: relative;
+    overflow: hidden;
+}
+.sec_unft_form .upload_image .item_image >img{
+    position: absolute;
+    /* width: 100%; */
+    min-width: 100%;
+    height: 100%;
+    object-fit: cover;
+    top:50%;
+    left:50%;
+    transform: translate(-50%,-50%);
+}
+
+.sec_unft_form .image_content{
+    width: 100%;
+}
+.sec_unft_form .image_content > div.mb-3{
+   margin-bottom: 2rem !important; 
+}
+.sec_unft_form .image_content label{
+    font-weight: 600;
+    font-size: 1.2em;
+}
+.sec_unft_form .image_content .form-control,.sec_unft_form .image_content .form-select{
+    padding: 0.75rem 1rem
+}
+.sec_unft_form .image_content .form-control:focus{
+    color: #212529;
+    background-color: #fff;
+    border-color: #888;
+    outline: 0;
+    box-shadow: unset;
+    transition: 1s;
+
+}
+.sec_unft_form .floating_form{
+    margin-top: 50px;
+    justify-content: center;
+}
+.sec_unft_form .floating_form .btn{
+    margin:0 8px;
+    max-width: 100px;
+    border-radius: 50px;
+    padding: 8px 16px;
+    border: transparent
+}
+.sec_unft_form .floating_form .btn#create_button{
+    background-color: #7E50FF;
+}
+.sec_unft_form .floating_form .btn#cancel_button{
+    background-color: #ddd;
+    color: #888
+}

--- a/static/js/edit_unft_api.js
+++ b/static/js/edit_unft_api.js
@@ -1,0 +1,112 @@
+document.addEventListener("DOMContentLoaded", function () {
+    handleUnftDetail()
+});
+// url을 불러오는 함수
+function getParams(params){
+    const url = window.location.href
+    const urlParams = new URL(url).searchParams;
+    const get_urlParams = urlParams.get(params);
+    return get_urlParams;
+}
+// edit 페이지 unft 모델 정보 불러오기
+async function handleUnftDetail(){
+    // url이 ?q="unft=1" 형태로 입력되지 않았을 때 에러메세지 출력
+   url_param = getParams("unft");
+   if (url_param == undefined){
+       alert("잘못된 경로입니다.");
+       location.href='/';
+   }
+   const response = await fetch('http://127.0.0.1:8000/unft/'+url_param+'/',{
+       headers: {
+           "content-type": "application/json",
+       },
+       method:'GET',
+   }).then(response => {
+        if(!response.ok){
+           throw new Error(`${response.status} 에러가 발생했습니다.`);    
+        } 
+       return response.json()
+   }).then(result => {
+       const response_json = result;
+       if(result['owner'] != localStorage.getItem("username")){
+            alert("수정 권한이 없습니다.")
+            location.href='/unft.html?unft='+url_param;
+        }
+       append_unft_card_detail(response_json)
+   }).catch(error => {
+       console.warn(error.message)
+   });
+}
+function append_unft_card_detail(data){
+    // 수정 조건    
+   const login_user = localStorage.getItem("username");
+   if (login_user==data['owner'] && login_user==data['creator']){
+        document.getElementById("title").removeAttribute("Disabled");
+        document.getElementById("desc").removeAttribute("Disabled");
+   }
+   document.getElementById("title").value = data['title'];
+   document.getElementById("desc").value = data['desc'];
+   document.getElementById("creator").value = data['creator'];
+   document.getElementById("status").querySelector('option[value=' + data['status'] + ']').setAttribute("selected",'selected');
+   document.getElementById("price").value = data['price'];
+   document.querySelector(".item_image img").setAttribute('src', 'http://127.0.0.1:8000/'+data['result_image']+'/');
+   toggleStatusUI(data['status'])
+}
+function insertCommas(num){
+   return num.toString().replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ",");
+}
+
+// 판매여부 select 관련 JS
+document.getElementById("status").addEventListener("change",function(){
+    const status = document.getElementById("status").value;
+    toggleStatusUI(status=="true"? true : false);
+});
+function toggleStatusUI(status){
+    if(status){
+        document.getElementById("price").removeAttribute("Disabled")
+        document.getElementById("price").parentElement.style.display = "block";
+    }else{
+        document.getElementById("price").setAttribute("Disabled","Disabled")
+        document.getElementById("price").parentElement.style.display = "none";
+    }
+}
+
+
+
+document.getElementById("btn_update_unft").addEventListener("click",function(){
+    handleUpdateUnft();
+});
+// unft 생성하기
+async function handleUpdateUnft() {
+    const title = document.getElementById("title").value;
+    const desc = document.getElementById("desc").value;
+    const status = document.getElementById("status").value;
+    const price = document.getElementById("price").value;
+    
+    const unft_formData = new FormData();
+    unft_formData.append("title",title);
+    unft_formData.append("desc",desc);
+    unft_formData.append("status",status);
+    unft_formData.append("price",price);
+    
+    const response = await fetch('http://127.0.0.1:8000/unft/'+url_param+'/',{
+        headers: {
+            // "Authorization":"Bearer " + localStorage.getItem("access"),
+            "Authorization":"Bearer " + "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl90eXBlIjoiYWNjZXNzIiwiZXhwIjoxNjY5NDEyMDk0LCJpYXQiOjE2NjkzNjg4OTQsImp0aSI6ImY1MjJhZDRmMzhlNzRiOWJhMjAxYjhjY2VjYjY4NDVjIiwidXNlcl9pZCI6MiwiZW1haWwiOiJ0ZXN0QGdtYWlsLmNvbSIsImlzX2FkbWluIjpmYWxzZX0.MnZoI1xvZhnE2lVVLPlC_P8f-KUta87ubr4B97k05rA",
+        },
+        method:'PUT',
+        body: unft_formData,
+    })
+    .then(response => {
+        if(!response.ok){
+            throw new Error(`${response.status} 에러가 발생했습니다.`);    
+        }
+        return response.json()
+    }).then(result => {
+            alert("U-NFT 수정에 성공했습니다!")
+            location.href='/unft.html?unft='+url_param;
+    }).catch(error => {
+        alert("U-NFT 수정에 실패하였습니다. \n 자세한 내용은 관리자에게 문의해주세요!");
+        console.warn(error.message);
+    });
+}


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 디자인 변경
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/19-unftEdit -> main

## 변경 사항
1. Design: U-NFT 수정 페이지 UI 구현
    - create_unft 페이지 베이스에서 html,css 디자인만 약간 수정

2. U-NFT 수정페이지에 unft 수정 API 연결
2.1. edit 페이지에 unft 데이터 넣기
	2.1.1. 로그인한 유저가 owner가 아닌경우 Error
		- "수정권한이없습니다" 출력
		- unft 상세페이지로 이동
	2.1.2. 로그인한 유저가 owner이면 edit페이지 접속 가능

 2.2. edit 페이지 수정권한
	2.2.1. 로그인한 유저가 owner & creator인 경우
		- title, desc, status, price form 활성화
![ ](https://user-images.githubusercontent.com/12287842/203965524-46d3b323-ff9a-4a32-80b0-efd54fb61a88.png)

	2.2.2  로그인한 유저가 owner인경우
		- status, price from 활성화
	
![screencapture-127-0-0-1-5500-edit-unft-html-2022-11-25-19_37_26](https://user-images.githubusercontent.com/12287842/203965386-b0315ce7-b7e6-44ed-b3da-71ab07c7604c.png)

    2.3. edit 페이지 form UI
	- status=true일 경우 price 보이게 처리
	- status=false일 경우 price 안보이게 처리
       
<img width="926" alt="Screenshot 2022-11-25 at 7 37 14 PM" src="https://user-images.githubusercontent.com/12287842/203965125-554002c4-292e-4159-bd39-7c9853f35ed1.png">
<img width="921" alt="Screenshot 2022-11-25 at 7 37 20 PM" src="https://user-images.githubusercontent.com/12287842/203965140-0a4a99d9-2767-4911-97c6-c353df367ae2.png">

## 테스트 결과
변경 사항을 설명하는데 도움이 되는 스크린샷이나 참고 자료를 추가해주세요.
![screencapture-127-0-0-1-5500-edit-unft-html-2022-11-25-19_35_15](https://user-images.githubusercontent.com/12287842/203964707-077fbbaf-d70e-4cb4-b8d8-198d827befc2.png)