### PR TITLE
Feat: 프로필페이지에 내새끼/내가만든작품/거래내역/제안내역 API 연결

### DIFF
--- a/profile.html
+++ b/profile.html
@@ -79,11 +79,12 @@
                     <div class="card_body">
                         <div class="card_content">
                             <div class="unft_card_title item_card_title">
-                                <span class="title">user name</span>
+                                <span class="title" id="profile_username">user name</span>
+                                <input type="hidden" id="profile_user_id">
                             </div>
                             <div class="item_card_editors flex">
-                                <p class="unft_card_owner item_card_editor"><span class="owner_field">email?</span>
-                                    <span class="owner">unft.unft.com</span></p>
+                                <p class="unft_card_owner item_card_editor"><span class="owner_field">email</span>
+                                    <span class="owner" id="profile_email">unft.unft.com</span></p>
                             </div>
                         </div>
                     </div>
@@ -92,15 +93,15 @@
             <section class="sec sec_unft_detail_tab">
                 <div class="tab_menu">
                     <ul class="tab_list">
-                        <li class="tab_item active"><a href="#tab_01">내 새끼</a></li>
-                        <li class="tab_item"><a href="#tab_02">내가 만든 작품</a></li>
-                        <li class="tab_item"><a href="#tab_03">거래내역</a></li>
-                        <li class="tab_item"><a href="#tab_04">제안내역</a></li>
+                        <li class="tab_item active" id="tab_menu_01" ><a href="#tab_01">내 새끼</a></li>
+                        <li class="tab_item" id="tab_menu_02"><a href="#tab_02">내가 만든 작품</a></li>
+                        <li class="tab_item" id="tab_menu_03"><a href="#tab_03">거래내역</a></li>
+                        <li class="tab_item" id="tab_menu_04"><a href="#tab_04">제안내역</a></li>
                     </ul>
                 </div>
                 <div class="tab_body">
                     <div class="tab_content unft_card_list active" id="tab_01">
-                        <div class='unft_card_list item_card_list' id="unft_card_list">
+                        <div class='unft_card_list item_card_list' id="owner_unft_card_list">
                             <div class="row">
                                 <!-- card start -->
                                 <div class="col-lg-3 col-md-4 col-6">
@@ -247,7 +248,7 @@
                         </div>
                     </div>
                     <div class="tab_content unft_card_list" id="tab_02">
-                        <div class='unft_card_list item_card_list' id="unft_card_list">
+                        <div class='unft_card_list item_card_list' id="creator_unft_card_list">
                             <div class="row">
                                 <!-- card start -->
                                 <div class="col-lg-3 col-md-4 col-6">
@@ -426,7 +427,7 @@
                                     </div>
                                 </div>
                             </div>
-                            <div class="tbody">
+                            <div class="tbody" id="deal_body">
                                 <div class="tr">
                                     <div class="td">
                                         <span>2022.11.21 01:16</span>
@@ -508,7 +509,7 @@
                                     </div>
                                 </div>
                             </div>
-                            <div class="tbody">
+                            <div class="tbody" id="to_offer_body">
                                 <div class="tr">
                                     <div class="td">
                                         <span>2022.11.21 01:16</span>
@@ -685,7 +686,7 @@
                                     </div>
                                 </div>
                             </div>
-                            <div class="tbody">
+                            <div class="tbody" id="from_offer_body">
                                 <div class="tr">
                                     <div class="td">
                                         <span>2022.11.21 01:16</span>

--- a/static/css/profile.css
+++ b/static/css/profile.css
@@ -127,9 +127,13 @@
     padding-right: 15px;
 }
 .table .tbody{
-    height: 300px;
+    min-height: 300px;
     overflow-y: scroll;
-
+}
+#tab_04 .table .tbody{
+    min-height: 100px;
+    max-height: 500px;
+    overflow-y: scroll;
 }
 .table .tr{
     display: flex;

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,8 +1,6 @@
 // profile tab jquery
 $('.tab_item').on("click",function(e){
     e.preventDefault(); 
-    console.log(this);
-    console.log($(this).find("a").attr("href"));
     const target_content_id = $(this).find("a").attr("href");
     $(".tab_item").removeClass('active');
     $(this).addClass("active");

--- a/static/js/mainAPI.js
+++ b/static/js/mainAPI.js
@@ -5,7 +5,6 @@ async function handleUnftList(){
     const response = await fetch('http://127.0.0.1:8000/unft/',{
         headers: {
             "content-type": "application/json",
-            // "Authorization":"Bearer " + localStorage.getItem("access")
         },
         method:'GET',
     }).then(response => {

--- a/static/js/profile.js
+++ b/static/js/profile.js
@@ -1,0 +1,277 @@
+document.addEventListener("DOMContentLoaded", function(){
+    handleProfile()
+    // handleOfferDetail()
+    // handleDealDetail()
+});
+// url을 불러오는 함수
+function getParams(params){
+    const url = window.location.href
+    const urlParams = new URL(url).searchParams;
+    const get_urlParams = urlParams.get(params);
+    return get_urlParams;
+}
+async function handleProfile(){
+    url_param = getParams("username");
+    if (url_param == undefined){
+        url_param = localStorage.getItem("username");
+    }
+    const response = await fetch('http://127.0.0.1:8000/users/'+url_param+'/',{
+        headers: {
+            "content-type": "application/json",
+        },
+        method:'GET',
+    }).then(response => {
+        if(!response.ok){
+            throw new Error(`${response.status} 에러가 발생했습니다.`);    
+        }
+        return response.json()
+    }).then(result => {
+        const response_json = result;
+        
+        document.getElementById("profile_user_id").value = response_json['id']
+        document.getElementById("profile_username").innerText = response_json['username']
+        document.getElementById("profile_email").innerText = response_json['email']
+        // 내새끼 리스트
+        let owner_unft_card_list = document.getElementById("owner_unft_card_list").querySelector(".row")
+        append_unft_card_list(response_json['own_unft'],owner_unft_card_list)
+        // 내가만든 작품 리스트
+        let creator_unft_card_list = document.getElementById("creator_unft_card_list").querySelector(".row")
+        append_unft_card_list(response_json['create_unft'],creator_unft_card_list)
+    }).catch(error => {
+        console.warn(error.message)
+    });
+}
+
+function append_unft_card_list(dataset,element){
+    element.innerHTML='';
+    dataset.forEach(data => {
+        let new_item = document.createElement('div');
+        new_item.className = 'col-lg-3 col-md-4 col-6';
+        new_item.innerHTML = `
+            <a href="/unft.html?unft=${data['id']}">
+                <div class='unft_card item_card' id='unft_${data['id']}'>
+                    <div class="card_header list_profile">
+                        <div class="unft_images item_image scale_up">
+                            <img aria-hidden="false" draggable="false" loading="lazy" src="http://127.0.0.1:8000${data['result_image']}">
+                        </div>
+                       ${data['status'] ? `<span class="unft_card_status">판매중</span>` : ``}
+                    </div>
+                    <div class="card_body">
+                        <div class="card_content">
+                            <p class="unft_card_title item_card_title"><span class="title">${data['title']}</span></p>
+                            <p class="unft_card_creator item_card_editor"><span class="creator">${data['creator']}</span></p>
+                        </div>
+                    </div>
+                    <div class="card_footer">
+                        ${data['status'] ? `<p>판매가</p>` : `<p>마지막 거래가</p>`}
+                        <p class="unft_card_price"><span class="price">${insertCommas(data['status'] ? data['price'] : 0)}</span> USD ~ </p>
+                    </div>
+                </div>
+            </a>
+        `;
+        element.append(new_item);
+    });
+}
+function insertCommas(num){
+    return num.toString().replace(/\B(?<!\.\d*)(?=(\d{3})+(?!\d))/g, ",");
+}
+
+
+// tab_menu_03탭 누르면 handleDealDetail() 호출
+document.getElementById("tab_menu_03").addEventListener("click",function(){
+    handleDealDetail();
+});
+async function handleDealDetail(){
+    let user_id = document.getElementById("profile_user_id").value;
+    let url_param = `from_user=${user_id}&to_user=${user_id}`;
+    const response = await fetch('http://127.0.0.1:8000/deal/?'+url_param,{
+        headers: {
+            "content-type": "application/json",
+        },
+        method:'GET',
+    }).then(response => {
+        if(!response.ok){
+            throw new Error(`${response.status} 에러 발생`)
+        }
+        return response.json()
+    }).then(result => {
+        let deal_body = document.getElementById("deal_body")
+        deal_body.innerHTML="";
+        if ("message" in result){
+            null_item = document.createElement("div");
+            null_item.className = "tr"
+            null_item.innerHTML = `
+                                <div class="td">
+                                    <span>${result["message"]}</span>
+                                </div>
+                                `
+            deal_body.append(null_item)
+        }else{
+            result.forEach(element => {
+                if (element.status === 1){
+                    let new_item = document.createElement("div");
+                    new_item.className = "tr"
+                    new_item.innerHTML = `
+                                        <div class="td">
+                                            <span>${element["updated_at"]}</span>
+                                        </div>
+                                        <div class="td">
+                                            <span>${element["from_user_username"]}</span>
+                                        </div>
+                                        <div class="td">
+                                            <span>${element["to_user_username"]}</span>
+                                        </div>
+                                        <div class="td">
+                                            <span>${element["price"]}</span>
+                                        </div>
+                                        `
+                        deal_body.append(new_item);
+                }else{
+                    null_item = document.createElement("div");
+                    null_item.className = "tr"
+                    null_item.innerHTML = `
+                                        <div class="td">
+                                            <span>거래 내역이 없습니다.</span>
+                                        </div>
+                                        `
+                    deal_body.append(null_item)
+                }
+            });
+        };
+    }).catch(error => {
+        console.error(error.message)
+    });
+};
+
+
+// tab_menu_04탭 누르면 handleOfferDetail(),handleFromOfferDetail() 호출
+document.getElementById("tab_menu_04").addEventListener("click",function(){
+    handleToOfferDetail();
+    handleFromOfferDetail();
+});
+async function handleToOfferDetail(){
+    let user_id = document.getElementById("profile_user_id").value;
+    let url_param = `to_user=${user_id}`;
+    const response = await fetch('http://127.0.0.1:8000/deal/?'+url_param,{
+        headers: {
+            "content-type": "application/json",
+        },
+        method:'GET',
+    }).then(response => {
+        if(!response.ok){
+            throw new Error(`${response.status} 에러가 발생했습니다.`)
+        }
+        return response.json()
+    }).then(result => {
+        let offer_body = document.getElementById("to_offer_body")
+        offer_body.innerHTML="";
+        if ("message" in result){
+            null_item = document.createElement("div");
+            null_item.className = "tr"
+            null_item.innerHTML = `
+                                <div class="td">
+                                    <span>${result["message"]}</span>
+                                </div>
+                                `
+            offer_body.append(null_item)
+        }else{
+            const response_json = result;
+            response_json.forEach(deal => {
+                if (deal.status !== 0){
+                    let dealStatus
+                    // 거래승인 상태시
+                    if (deal.status === 1){
+                        dealStatus = "거래승인"
+                    }else if (deal.status === 2){
+                        dealStatus = "거래거절"
+                    }else{
+                        dealStatus = "제안중"
+                    }
+                
+                    let new_item = document.createElement("div");
+                    new_item.className = "tr"
+                    new_item.innerHTML = `
+                                        <div class="td">
+                                            <span>${deal["updated_at"]}</span>
+                                        </div>
+                                        <div class="td">
+                                            <span>${deal["to_user_username"]}</span>
+                                        </div>
+                                        <div class="td">
+                                            <span>${dealStatus}</span>
+                                        </div>
+                                        <div class="td">
+                                            <span>${deal["price"]}</span>
+                                        </div>
+                                        `
+                    offer_body.append(new_item);
+                };
+            });
+        };
+    }).catch(error => {
+        console.error(error.message)
+    })
+};
+async function handleFromOfferDetail(){
+    let user_id = document.getElementById("profile_user_id").value;
+    let url_param = `from_user=${user_id}`;
+    const response = await fetch('http://127.0.0.1:8000/deal/?'+url_param,{
+        headers: {
+            "content-type": "application/json",
+        },
+        method:'GET',
+    }).then(response => {
+        if(!response.ok){
+            throw new Error(`${response.status} 에러가 발생했습니다.`)
+        }
+        return response.json()
+    }).then(result => {
+        let offer_body = document.getElementById("from_offer_body")
+        offer_body.innerHTML="";
+        if ("message" in result){
+            null_item = document.createElement("div");
+            null_item.className = "tr"
+            null_item.innerHTML = `
+                                <div class="td">
+                                    <span>${result["message"]}</span>
+                                </div>
+                                `
+            offer_body.append(null_item)
+        }else{
+            const response_json = result;
+            response_json.forEach(deal => {
+                if (deal.status !== 0){
+                    let dealStatus
+                    // 거래승인 상태시
+                    if (deal.status === 1){
+                        dealStatus = "거래승인"
+                    }else if (deal.status === 2){
+                        dealStatus = "거래거절"
+                    }else{
+                        dealStatus = "제안중"
+                    }
+                
+                    let new_item = document.createElement("div");
+                    new_item.className = "tr"
+                    new_item.innerHTML = `
+                                        <div class="td">
+                                            <span>${deal["updated_at"]}</span>
+                                        </div>
+                                        <div class="td">
+                                            <span>${deal["to_user_username"]}</span>
+                                        </div>
+                                        <div class="td">
+                                            <span>${dealStatus}</span>
+                                        </div>
+                                        <div class="td">
+                                            <span>${deal["price"]}</span>
+                                        </div>
+                                        `
+                    offer_body.append(new_item);
+                };
+            });
+        };
+    }).catch(error => {
+        console.error(error.message)
+    })
+};


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 디자인 변경
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/profileAPI -> main

## 변경 사항
1. 프로필페이지 유저의 프로필 받아오기
	- 'users/<username>'으로 API요청
	- 해당 user의 정보를 받아서 username/email/user_id값 저장

2. 내새끼/내가만든작품API 연결
	- '/users/<username>'으로 API 요청(1번)
	- 1번에서 받은 데이터 중에서 create_unft, own_unft 데이터 출력
	
![Screenshot 2022-11-26 at 2 17 59 AM](https://user-images.githubusercontent.com/12287842/204032028-609d656c-2de0-4a9b-91d2-93ed58db01eb.png)

3. 거래내역 API 연결
	- 'deal/?from_user={user_id}&to_user={user_id}'로 API요청
![Screenshot 2022-11-26 at 2 18 23 AM](https://user-images.githubusercontent.com/12287842/204032073-a88a0b7f-4cfd-42c6-bb6e-8b6b65c6341c.png)

4. 제안내역 API 연결
	4.1 내가 제안한 내역
		- 'deal/?to_user={user_id}'로 API요청
	4.2 내가 제안 받은내역
		- 'deal/?from_user={user_id}'로 API요청
![Screenshot 2022-11-26 at 2 18 49 AM](https://user-images.githubusercontent.com/12287842/204032134-4d65d0de-f7d1-43f4-b7fe-6e474af83605.png)


## 테스트 결과
변경 사항을 설명하는데 도움이 되는 스크린샷이나 참고 자료를 추가해주세요.